### PR TITLE
Add chinese translation

### DIFF
--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -1,0 +1,8 @@
+---
+hide:
+  - navigation
+---
+
+# Roll Off Club
+
+TODO: translate contents of index.md file to chinese

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,10 @@ plugins:
           name: 한국어 (Korean)
           build: true
           site_name: "Roll Off 클럽"
+        zh:
+          name: TODO (Chinese)
+          build: true
+          site_name: "TODO"
       nav_translations:
         ko:
           Home: 홈
@@ -135,6 +139,17 @@ plugins:
           Easy Variations: 쉬운 난도 변형
           Advanced: 고급
           Glossary: 용어집
+        zh:
+          Home: TODO
+          Getting Started: TODO
+          Rolls: TODO
+          Variations: TODO
+          Hardest Variations: TODO
+          Hard Variations: TODO
+          Medium Variations: TODO
+          Easy Variations: TODO
+          Advanced: TODO
+          Glossary: TODO
 
 extra:
   social:


### PR DESCRIPTION
This shows the setup code required to begin translating the site to chinese.

For every markdown file, you basically create a duplicate with the suffix `.zh.md`.

There are a few other things that need to be translated in the `mkdocs.yml` file which I've marked with `TODO`.

For the images containing english words, you'll have to send me the chinese characters to use instead and I can recreate the images myself.